### PR TITLE
Use sort to make sure opa rego policies are loaded in a correct order…

### DIFF
--- a/tauth/authz/engines/opa/engine.py
+++ b/tauth/authz/engines/opa/engine.py
@@ -12,7 +12,7 @@ from opa_client.errors import (
 from redbaby.pyobjectid import PyObjectId
 
 from tauth.authz.policies.models import AuthorizationPolicyDAO
-from tauth.utils import reading
+from tauth.settings import Settings
 
 from ....schemas import Infostar
 from ...policies.controllers import upsert_one
@@ -48,8 +48,12 @@ class OPAEngine(AuthorizationInterface):
         logger.debug("OPA Engine is running.")
 
     def _initialize_db_policies(self):
-        policies = reading.read_many(
-            infostar=SYSTEM_INFOSTAR, model=AuthorizationPolicyDAO
+        policies = AuthorizationPolicyDAO.find(
+            filter={},
+            alias=Settings.get().REDBABY_ALIAS,
+            validate=True,
+            lazy=False,
+            sort=[("created_at", -1)]
         )
         logger.info(
             f"Loading DB policies into OPA. Policies loaded: {len(policies)}"

--- a/tauth/entities/routes.py
+++ b/tauth/entities/routes.py
@@ -202,11 +202,7 @@ async def add_entity_permission(
         model=PermissionDAO,
         identifier=permission_id,
     )
-    if not permission:
-        raise HTTPException(
-            status_code=s.HTTP_404_NOT_FOUND,
-            detail="Permission not found.",
-        )
+
     logger.debug(f"permission found: {permission!r}.")
     # 409 in case the permission is already attached
     for p in entity.permissions:


### PR DESCRIPTION
…, due to dependencies in between policies