### PR TITLE
Add fields to class

### DIFF
--- a/tauth/schemas/infostar.py
+++ b/tauth/schemas/infostar.py
@@ -10,6 +10,10 @@ class InfostarExtra(TypedDict, total=False):
     os: str
     url: str  # reverse dns
     user_agent: str
+    name: str
+    nickname: str
+    email: str
+    picture: str
 
 
 class Infostar(BaseModel):


### PR DESCRIPTION
Pydantic does not include fields that are not explicitly defined into the class, even though it is a TypedDict
